### PR TITLE
First pass at making Spinner fullscreen and more visible

### DIFF
--- a/client/app/components/Spinner/index.js
+++ b/client/app/components/Spinner/index.js
@@ -1,13 +1,22 @@
 import React from 'react';
 
+import bulma from 'styles/bulma.scss';
 import styles from './styles.scss';
 
 const Spinner = () => (
-  <div className={styles.spinner}>
-    <div className={styles.bounce1}></div>
-    <div className={styles.bounce2}></div>
-    <div className={styles.bounce3}></div>
-  </div>
+  <section id={styles.spinner} className={`${bulma.hero} ${bulma['is-fullheight']} ${styles.fullheightHeroSubNav}`}>
+    <div className={bulma['hero-body']}>
+      <div className={bulma.container}>
+        <h1 className={bulma.title}>
+          <div className={styles.spinner}>
+            <div className={styles.bounce1}></div>
+            <div className={styles.bounce2}></div>
+            <div className={styles.bounce3}></div>
+          </div>
+        </h1>
+      </div>
+    </div>
+  </section>
 );
 
 export default Spinner;

--- a/client/app/components/Spinner/styles.scss
+++ b/client/app/components/Spinner/styles.scss
@@ -1,11 +1,11 @@
 .spinner {
   margin: 100px auto 0;
-  width: 70px;
+  width: 150px;
   text-align: center;
 
   > div {
-    width: 18px;
-    height: 18px;
+    width: 50px;
+    height: 50px;
     background-color: #333;
 
     border-radius: 100%;
@@ -23,6 +23,10 @@
     -webkit-animation-delay: -0.16s;
     animation-delay: -0.16s;
   }
+}
+
+section#spinner.fullheightHeroSubNav {
+  min-height: calc(100vh - 3.25rem);
 }
 
 @-webkit-keyframes sk-bouncedelay {


### PR DESCRIPTION
-Embedding spinner elements inside of a fullheight bulma hero section to take up the screen
-Increasing size of blobs from 18px to 50px radius, container from 70px to 150px to accomodate increase
-Adding styles to hero to offset the height by the height of the navbar (3.25rem)
-NEW LEARNING: id's inside CSS Module'd scss is namespaced just like classes (name__hash, etc), so to use it as an id attribute it ALSO has to be applied via import as such: id={styles.idNameInScss}